### PR TITLE
Fix Docker Image Tag Mismatch

### DIFF
--- a/.github/workflows/demo-build.yml
+++ b/.github/workflows/demo-build.yml
@@ -65,13 +65,14 @@ jobs:
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
           ECR_REPO_URI="${{ secrets.DEMO_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.DEMO_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
-          MEDIAMTX_TAG=$(jq -r '.context."dev-test".docker.mediamtxImageTag' cdk.json)
+          VERSION=$(jq -r '.context."dev-test".mediamtx.version' cdk.json)
+          REVISION=$(jq -r '.context."dev-test".mediamtx.buildRevision' cdk.json)
           
           if [[ "${{ github.event.inputs.force_rebuild }}" == "true" ]]; then
             TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-            MEDIAMTX_TAG="mediamtx-${MEDIAMTX_TAG}-${TIMESTAMP}"
+            MEDIAMTX_TAG="mediamtx-${VERSION}-r${REVISION}-${TIMESTAMP}"
           else
-            MEDIAMTX_TAG="mediamtx-${MEDIAMTX_TAG}"
+            MEDIAMTX_TAG="mediamtx-${VERSION}-r${REVISION}"
           fi
           
           echo "ecr-repo-uri=$ECR_REPO_URI" >> $GITHUB_OUTPUT

--- a/.github/workflows/production-build.yml
+++ b/.github/workflows/production-build.yml
@@ -62,13 +62,14 @@ jobs:
           ECR_REPO_NAME=$(echo $ECR_REPO_ARN | cut -d'/' -f2)
           ECR_REPO_URI="${{ secrets.PROD_AWS_ACCOUNT_ID }}.dkr.ecr.${{ secrets.PROD_AWS_REGION }}.amazonaws.com/${ECR_REPO_NAME}"
           
-          MEDIAMTX_TAG=$(jq -r '.context."prod".docker.mediamtxImageTag' cdk.json)
+          VERSION=$(jq -r '.context."prod".mediamtx.version' cdk.json)
+          REVISION=$(jq -r '.context."prod".mediamtx.buildRevision' cdk.json)
           
           if [[ "${{ github.event.inputs.force_rebuild }}" == "true" ]]; then
             TIMESTAMP=$(date +%Y%m%d-%H%M%S)
-            MEDIAMTX_TAG="mediamtx-${MEDIAMTX_TAG}-${TIMESTAMP}"
+            MEDIAMTX_TAG="mediamtx-${VERSION}-r${REVISION}-${TIMESTAMP}"
           else
-            MEDIAMTX_TAG="mediamtx-${MEDIAMTX_TAG}"
+            MEDIAMTX_TAG="mediamtx-${VERSION}-r${REVISION}"
           fi
           
           echo "ecr-repo-uri=$ECR_REPO_URI" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Build workflows were creating different tags than deploy workflows expected.

## Problem
- Build: `mediamtx-latest` (from docker.mediamtxImageTag)
- Deploy: `mediamtx-1.13.1-r1` (from mediamtx.version + buildRevision)

## Solution
Updated build workflows to use version-revision format:
- demo-build.yml: Use mediamtx.version + mediamtx.buildRevision
- production-build.yml: Use mediamtx.version + mediamtx.buildRevision

## Result
Both now generate: `mediamtx-${VERSION}-r${REVISION}`

Ensures built images match deployment consumption.
