### PR TITLE
Ecr-fix

### DIFF
--- a/lib/constructs/media-ecs-service.ts
+++ b/lib/constructs/media-ecs-service.ts
@@ -75,7 +75,7 @@ export class MediaEcsService extends Construct {
 
     // Add ECR permissions to execution role for image pulling
     if (this.taskDefinition.executionRole) {
-      this.taskDefinition.executionRole.addToPolicy(new iam.PolicyStatement({
+      (this.taskDefinition.executionRole as iam.Role).addToPolicy(new iam.PolicyStatement({
         effect: iam.Effect.ALLOW,
         actions: [
           'ecr:GetAuthorizationToken',

--- a/lib/constructs/media-ecs-service.ts
+++ b/lib/constructs/media-ecs-service.ts
@@ -73,6 +73,20 @@ export class MediaEcsService extends Construct {
       taskRole: taskRole,
     });
 
+    // Add ECR permissions to execution role for image pulling
+    if (this.taskDefinition.executionRole) {
+      this.taskDefinition.executionRole.addToPolicy(new iam.PolicyStatement({
+        effect: iam.Effect.ALLOW,
+        actions: [
+          'ecr:GetAuthorizationToken',
+          'ecr:BatchCheckLayerAvailability',
+          'ecr:GetDownloadUrlForLayer',
+          'ecr:BatchGetImage'
+        ],
+        resources: ['*']
+      }));
+    }
+
     // Add EFS volume
     this.taskDefinition.addVolume({
       name: 'mediamtx-config',

--- a/test/unit/constructs/media-ecs-mocked.test.ts
+++ b/test/unit/constructs/media-ecs-mocked.test.ts
@@ -10,7 +10,8 @@ jest.mock('aws-cdk-lib/aws-ecs', () => ({
       addToPrincipalOrResource: jest.fn()
     },
     executionRole: {
-      addToPrincipalOrResource: jest.fn()
+      addToPrincipalOrResource: jest.fn(),
+      addToPolicy: jest.fn()
     }
   })),
   FargateService: jest.fn().mockImplementation(() => ({


### PR DESCRIPTION
# Fix ECR Permissions for ECS Container Image Pulling

## Problem
ECS tasks failing with `AccessDeniedException` when pulling container images from ECR.

## Solution
Added required ECR permissions to ECS task execution role:
- `ecr:GetAuthorizationToken` - Authenticate with ECR registry
- `ecr:BatchCheckLayerAvailability` - Check image layer availability  
- `ecr:GetDownloadUrlForLayer` - Get layer download URLs
- `ecr:BatchGetImage` - Pull container images

## Files Changed
- `lib/constructs/media-ecs-service.ts`

## Impact
Fixes critical ECS service deployment failure. Low risk - only adds necessary ECR permissions.
