### PR TITLE
Fix ECR Permissions Using AWS Managed Policy Pattern

### DIFF
--- a/test/unit/constructs/media-ecs-mocked.test.ts
+++ b/test/unit/constructs/media-ecs-mocked.test.ts
@@ -38,6 +38,9 @@ jest.mock('aws-cdk-lib/aws-iam', () => ({
     addActions: jest.fn(),
     addResources: jest.fn()
   })),
+  ManagedPolicy: {
+    fromAwsManagedPolicyName: jest.fn().mockReturnValue({})
+  },
   Effect: { ALLOW: 'Allow' }
 }));
 


### PR DESCRIPTION
## Problem
ECS tasks still failing with ECR `AccessDeniedException` despite adding explicit ECR permissions.

## Root Cause Analysis
Compared with tak-infra implementation and found key difference:
- **tak-infra**: Uses `AmazonECSTaskExecutionRolePolicy` managed policy
- **media-infra**: Was adding explicit ECR permissions manually

## Solution
Aligned with tak-infra pattern by using AWS managed policy instead of custom permissions:
- Removed explicit ECR permission statements
- Rely on `AmazonECSTaskExecutionRolePolicy` which includes all required ECR permissions
- Updated test mocks to support `ManagedPolicy.fromAwsManagedPolicyName`

## Benefits
- **AWS Best Practice**: Uses managed policies instead of custom permissions
- **Consistency**: Matches tak-infra implementation pattern
- **Maintainability**: AWS manages policy updates automatically
- **Simplicity**: Less custom permission management code

## Files Changed
- `lib/constructs/media-ecs-service.ts` - Use managed policy for execution role
- `test/unit/constructs/media-ecs-mocked.test.ts` - Add ManagedPolicy mock