### PR TITLE
Align media-infra with upstream dfpc-coe implementation

### DIFF
--- a/docker-container/mediamtx.yml
+++ b/docker-container/mediamtx.yml
@@ -1,4 +1,4 @@
-# This Config file is reduced to the min required use case for COTAK
+# This Config file is reduced to the min required use case for TAK.NZ
 # View: https://github.com/bluenviron/mediamtx/blob/main/mediamtx.yml
 # For full MediaMTX Config Options
 
@@ -11,7 +11,7 @@ writeQueueSize: 1024
 udpMaxPayloadSize: 1472
 
 authMethod: http
-authHTTPAddress: http://example.com
+authHTTPAddress: CLOUDTAK_URL/api/video/auth
 authHTTPExclude: []
 
 api: yes

--- a/docker-container/persist.ts
+++ b/docker-container/persist.ts
@@ -1,21 +1,23 @@
-import assert from 'node:assert';
 import jwt from 'jsonwebtoken';
-import { diffString }  from 'json-diff';
 import { fetch } from 'undici';
-import fs from 'node:fs';
-import fsp from 'node:fs/promises';
 import cron from 'node-cron';
-import YAML from 'yaml';
 
-export type RemotePath = {
+export type Path = {
+    name: string,
+    runOnInit: string,
+    record: boolean,
+};
+
+export type CloudTAKRemotePath = {
     id: number,
     path: string,
+    recording: boolean,
     proxy: string | null,
 }
 
-export type RemotePaths = {
+export type CloudTAKRemotePaths = {
     total: number,
-    items: Array<RemotePath>
+    items: Array<CloudTAKRemotePath>
 }
 
 if (import.meta.url === `file://${process.argv[1]}`) {
@@ -23,265 +25,207 @@ if (import.meta.url === `file://${process.argv[1]}`) {
     if (!process.env.MediaSecret) throw new Error('MediaSecret Env Var not set');
     if (!process.env.SigningSecret) throw new Error('SigningSecret Env Var not set');
 
-    // Read current config (base config is copied at startup)
-    const currentConfig = YAML.parse(String(fs.readFileSync('/opt/mediamtx/mediamtx.yml')));
-    
-    writeConfig(defaultConfig(currentConfig));
+    // Wait for MediaMTX to be ready
+    while (true) {
+        try {
+            const res = await fetch('http://localhost:9997/v3/config/global/get');
+            if (res.ok) break;
+        } catch {}
+        await new Promise(resolve => setTimeout(resolve, 2000));
+    }
 
-    // Using 1-second sync for faster path availability
-    
     await schedule();
 }
 
-let syncInProgress = false;
-const CLEANUP_GRACE_PERIOD = 5 * 60 * 1000; // 5 minutes
-const cleanupTracker = new Map<string, number>(); // Track cleanup timing separately
-
 export async function schedule() {
-    // Add new paths every 10 seconds (avoid race with CloudTAK API calls)
     cron.schedule('*/10 * * * * *', async () => {
-        if (syncInProgress) {
-            console.error('Sync already in progress, skipping');
-            return;
-        }
-        
-        syncInProgress = true;
         try {
-            const currentConfig = await readConfig();
-            const newPaths = await globalPaths();
-            
-            let pathsAdded = false;
-            let pathsRemoved = false;
-            
-            // Ensure paths object exists
-            if (!currentConfig.paths) {
-                currentConfig.paths = {};
-            }
-            
-            // Add new paths
-            for (const remote of newPaths) {
-                if (remote.proxy && !currentConfig.paths[remote.path]) {
-                    currentConfig.paths[remote.path] = {
-                        name: remote.path,
-                        source: remote.proxy,
-                        sourceOnDemand: true
-                    };
-                    pathsAdded = true;
-                    console.error(`Added new path: ${remote.path}`);
-                }
-            }
-            
-            // Lazy cleanup with grace period
-            const remotePaths = new Set(newPaths.map(p => p.path));
-            const now = Date.now();
-            
-            for (const pathName of Object.keys(currentConfig.paths)) {
-                if (!remotePaths.has(pathName)) {
-                    // Track when path was first marked for cleanup
-                    if (!cleanupTracker.has(pathName)) {
-                        cleanupTracker.set(pathName, now);
-                    } else if (now - cleanupTracker.get(pathName)! > CLEANUP_GRACE_PERIOD) {
-                        delete currentConfig.paths[pathName];
-                        cleanupTracker.delete(pathName);
-                        pathsRemoved = true;
-                        console.error(`Removed stale path: ${pathName}`);
-                    }
-                } else {
-                    // Path exists in CloudTAK - clear cleanup marker
-                    cleanupTracker.delete(pathName);
-                }
-            }
-            
-            if (pathsAdded || pathsRemoved) {
-                writeConfig(defaultConfig(currentConfig));
-                console.error(`Sync completed - ${Object.keys(currentConfig.paths).length} total paths`);
-            }
+            await sync();
         } catch (err) {
-            console.error('Path sync failed:', err instanceof Error ? err.message : err);
-        } finally {
-            syncInProgress = false;
+            console.error('Sync failed:', err instanceof Error ? err.message : err);
         }
     });
-
-    console.error('Path sync started - checking every 10 seconds');
-    console.error('Lazy cleanup enabled - 5 minute grace period');
 }
 
-export function defaultConfig(config: Record<string, any>): string {
-    config.authMethod = 'http';
-    config.authHTTPAddress = process.env.CLOUDTAK_URL + '/api/video/auth';
-    config.authHTTPExclude = [];
-    config.authInternalUsers = [];
-
-    config.readTimeout = '10s';
-    config.writeTimeout = '10s';
-    
-    // Path server handles on-demand requests via HTTP
-
-    let configstr = YAML.stringify(config, (key, value) => {
-        if (typeof value === 'boolean') {
-            return value === true ? 'yes' : 'no';
-        } else {
-            return value;
-        }
-    });
-
-    // This is janky but MediaMTX wants `no` as a string and not a boolean
-    // and I can't get the YAML library to respect that...
-    configstr = configstr.split('\n').map((line) => {
-        line = line.replace(/^rtspEncryption: no/, 'rtspEncryption: "no"');
-        line = line.replace(/^rtmpEncryption: no/, 'rtmpEncryption: "no"');
-        return line;
-    }).join('\n');
-
-    return configstr;
-}
-
-async function readConfig(): Promise<Record<string, any>> {
+/**
+ * Perform a single sync operation
+ */
+export async function sync() {
     try {
-        const configData = await fsp.readFile('/opt/mediamtx/mediamtx.yml', 'utf8');
-        return YAML.parse(configData);
+        await syncPaths();
     } catch (err) {
-        console.error('Failed to read config file:', err instanceof Error ? err.message : err);
-        throw new Error('Config file read failed');
+        // MediaMTX might not be ready yet, will retry on next cron
+        throw err;
     }
 }
 
-export function writeConfig(config: string): void {
-    try {
-        fs.writeFileSync('/opt/mediamtx/mediamtx.yml.new', config);
-        // Ref: https://github.com/bluenviron/mediamtx/issues/937
-        fs.renameSync(
-            '/opt/mediamtx/mediamtx.yml.new',
-            '/opt/mediamtx/mediamtx.yml'
-        );
-    } catch (err) {
-        console.error('Failed to write config file:', err instanceof Error ? err.message : err);
-        throw new Error('Config file write failed');
-    }
-}
+/**
+ * Sync Paths from CloudTAK to Media Server
+ */
+export async function syncPaths(): Promise<void> {
+    const paths = await listCloudTAKPaths();
 
-export default async function persist(): Promise<Record<string, any>> {
-    const base = await globalConfig();
+    const existing = await listMediaMTXPathsMap();
 
-    const paths = (await globalPaths()).map((remote: RemotePath) => {
-        if (remote.proxy) {
-            return {
-                name: remote.path,
-                source: remote.proxy,
-                sourceOnDemand: true
-            };
+    for (const path of paths.values()) {
+        const exists = existing.get(path.path);
+
+        const payload = createPayload(path);
+
+        if (!exists) {
+            await createMediaMTXPath(payload);
         } else {
-            return {
-                name: remote.path
-            };
+            if (
+                exists.record !== payload.record
+                || exists.runOnInit !== payload.runOnInit
+            ) {
+                await updateMediaMTXPath(payload);
+            }
+        }
+    }
+
+    for (const exist of existing.keys()) {
+        if (!paths.has(exist)) {
+            await removeMediaMTXPath(exist);
+        }
+    }
+}
+
+export function createPayload(path: CloudTAKRemotePath): Path {
+    if (path.proxy) {
+        return {
+            name: path.path,
+            record: path.recording,
+            runOnInit: `ffmpeg -re -i '${path.proxy}' -vcodec libx264 -profile:v baseline -g 60 -acodec aac -f mpegts srt://127.0.0.1:8890?streamid=publish:${path.path}`
+        };
+    } else {
+        return {
+            name: path.path,
+            record: path.recording,
+            runOnInit: ''
+        };
+    }
+}
+
+export async function removeMediaMTXPath(uuid: string): Promise<void> {
+    const url = new URL(`http://localhost:9997/v3/config/paths/delete/${uuid}`);
+
+    const res = await fetch(url, {
+        method: 'DELETE',
+        headers: {
+            'Authorization': `Basic ${btoa(`management:${process.env.MediaSecret}`)}`
         }
     });
 
-    base.paths = {};
-
-    for (const path of paths) {
-        base.paths[path.name] = path;
-    }
-
-    return base;
+    if (!res.ok) throw new Error(await res.text());
 }
 
-export async function globalPaths(): Promise<Array<RemotePath>> {
-    const maxRetries = 3;
-    let retryCount = 0;
-    
-    while (retryCount < maxRetries) {
-        try {
-            let total = 0;
-            const limit = 100;
-            let page = 0;
-            const paths = [];
+export async function createMediaMTXPath(path: Path): Promise<void> {
+    const url = new URL(`http://localhost:9997/v3/config/paths/add/${path.name}`);
 
-            do {
-                const url = new URL(process.env.CLOUDTAK_URL + '/api/video/lease');
-                url.searchParams.append('limit', String(limit));
-                url.searchParams.append('expired', 'false');
-                url.searchParams.append('ephemeral', 'all');
-                url.searchParams.append('impersonate', 'true');
-                url.searchParams.append('page', String(page));
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Basic ${btoa(`management:${process.env.MediaSecret}`)}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(path)
+    });
 
-                const controller = new AbortController();
-                const timeoutId = setTimeout(() => controller.abort(), 10000);
-                
-                const res = await fetch(url, {
-                    method: 'GET',
-                    headers: {
-                        Authorization: `Bearer etl.${jwt.sign({ access: 'lease', id: 'any', internal: true }, process.env.SigningSecret)}`
-                    },
-                    signal: controller.signal
-                });
-                
-                clearTimeout(timeoutId);
-
-                if (!res.ok) {
-                    throw new Error(`CloudTAK API error: ${res.status} ${await res.text()}`);
-                }
-
-                const body = await res.json() as RemotePaths;
-                total = body.total;
-                paths.push(...body.items);
-                ++page;
-            } while (total > page * limit);
-
-            return paths;
-        } catch (err) {
-            retryCount++;
-            console.error(`CloudTAK API attempt ${retryCount}/${maxRetries} failed:`, err instanceof Error ? err.message : err);
-            
-            if (retryCount >= maxRetries) {
-                throw new Error(`CloudTAK API failed after ${maxRetries} attempts: ${err instanceof Error ? err.message : err}`);
-            }
-            
-            // Exponential backoff: 1s, 2s, 4s
-            await new Promise(resolve => setTimeout(resolve, 1000 * Math.pow(2, retryCount - 1)));
-        }
-    }
-    
-    return []; // Should never reach here
+    if (!res.ok) throw new Error(await res.text());
 }
 
-export async function globalConfig(): Promise<any> {
-    const maxRetries = 3;
-    let retryCount = 0;
-    
-    while (retryCount < maxRetries) {
-        try {
-            const controller = new AbortController();
-            const timeoutId = setTimeout(() => controller.abort(), 5000);
-            
-            const res = await fetch('http://localhost:9997/v3/config/global/get', {
-                method: 'GET',
-                headers: {
-                    Authorization: `Basic ${Buffer.from(`management:${process.env.MediaSecret}`).toString('base64')}`
-                },
-                signal: controller.signal
-            });
-            
-            clearTimeout(timeoutId);
+export async function updateMediaMTXPath(path: Path): Promise<void> {
+    const url = new URL(`http://localhost:9997/v3/config/paths/replace/${path.name}`);
 
-            if (!res.ok) {
-                throw new Error(`MediaMTX API error: ${res.status} ${await res.text()}`);
-            }
+    const res = await fetch(url, {
+        method: 'POST',
+        headers: {
+            'Authorization': `Basic ${btoa(`management:${process.env.MediaSecret}`)}`,
+            'Content-Type': 'application/json'
+        },
+        body: JSON.stringify(path)
+    });
 
-            return await res.json();
-        } catch (err) {
-            retryCount++;
-            console.error(`MediaMTX API attempt ${retryCount}/${maxRetries} failed:`, err instanceof Error ? err.message : err);
-            
-            if (retryCount >= maxRetries) {
-                throw new Error(`MediaMTX API failed after ${maxRetries} attempts: ${err instanceof Error ? err.message : err}`);
+    if (!res.ok) throw new Error(await res.text());
+}
+
+export async function listMediaMTXPathsMap(): Promise<Map<string, Path>> {
+    let total = 0;
+    const limit = 100;
+    let page = 0;
+
+    const paths = new Map<string, Path>();
+
+    do {
+        const url = new URL('http://localhost:9997/v3/config/paths/list');
+        url.searchParams.append('itemsPerPage', String(limit));
+        url.searchParams.append('page', String(page));
+
+        const res = await fetch(url, {
+            method: 'GET',
+            headers: {
+                'Authorization': `Basic ${btoa(`management:${process.env.MediaSecret}`)}`
             }
-            
-            // Wait 1 second before retry
-            await new Promise(resolve => setTimeout(resolve, 1000));
+        });
+
+        if (!res.ok) {
+            console.error(res);
+            throw new Error(await res.text());
         }
-    }
-    
-    return {}; // Should never reach here
+
+        const body = await res.json() as {
+            pageCount: number,
+            itemCount: number,
+            items: Array<Path>
+        };
+
+        total = body.itemCount;
+
+        for (const item of body.items) {
+            paths.set(item.name, item);
+        }
+
+        ++page;
+    } while (total > page * limit);
+
+    return paths;
+}
+
+export async function listCloudTAKPaths(): Promise<Map<string, CloudTAKRemotePath>> {
+    let total = 0;
+    const limit = 100;
+    let page = 0;
+
+    const paths = new Map();
+
+    do {
+        const url = new URL(process.env.CLOUDTAK_URL + '/api/video/lease');
+        url.searchParams.append('limit', String(limit));
+        url.searchParams.append('expired', 'false');
+        url.searchParams.append('ephemeral', 'all');
+        url.searchParams.append('impersonate', 'true');
+        url.searchParams.append('page', String(page));
+
+        const res = await fetch(url, {
+            method: 'GET',
+            headers: {
+                Authorization: `Bearer etl.${jwt.sign({ access: 'lease', id: 'any', internal: true }, String(process.env.SigningSecret))}`
+            }
+        });
+
+        if (!res.ok) throw new Error(await res.text());
+
+        const body = await res.json() as CloudTAKRemotePaths;
+
+        total = body.total;
+
+        for (const item of body.items) {
+            paths.set(item.path, item);
+        }
+
+        ++page;
+    } while (total > page * limit);
+
+    return paths;
 }

--- a/docker-container/start
+++ b/docker-container/start
@@ -1,42 +1,15 @@
-#!/bin/sh
+#!/bin/bash
+#
+# Add MediaConfig File
+#
 
-# Container startup script following TAK.NZ pattern
-# This script initializes MediaMTX with dynamic configuration
+set -euo pipefail
 
-set -e
+LOGLEVEL=${LOG_LEVEL:-info}
 
-echo "Starting MediaMTX container..."
+yq -i ".authHTTPAddress = \"$CLOUDTAK_URL/api/video/auth\"" /mediamtx.yml
+yq -i ".logLevel = \"$LOGLEVEL\"" /mediamtx.yml
 
-# Validate required environment variables
-if [ -z "$CLOUDTAK_URL" ]; then
-    echo "ERROR: CLOUDTAK_URL environment variable is required"
-    exit 1
-fi
-
-if [ -z "$SigningSecret" ]; then
-    echo "ERROR: SigningSecret environment variable is required"
-    exit 1
-fi
-
-if [ -z "$MediaSecret" ]; then
-    echo "ERROR: MediaSecret environment variable is required"
-    exit 1
-fi
-
-echo "Environment variables validated"
-
-echo "Contents:"
-ls /opt/mediamtx/
-
-# Copy base configuration
-echo "Copying base MediaMTX configuration..."
-cp "/mediamtx.base.yml" "/opt/mediamtx/mediamtx.yml"
-
-# Start persist script in background
-echo "Starting configuration persistence..."
-cd /app
 npx tsx persist.ts &
 
-# Start MediaMTX with the configuration
-echo "Starting MediaMTX server..."
-exec /mediamtx /opt/mediamtx/mediamtx.yml
+/mediamtx /mediamtx.yml

--- a/docker/media-infra/Dockerfile
+++ b/docker/media-infra/Dockerfile
@@ -2,10 +2,10 @@ ARG MEDIAMTX_VERSION=1.13.1
 FROM bluenviron/mediamtx:${MEDIAMTX_VERSION}-ffmpeg
 
 # Install dependencies
-RUN apk add --no-cache tini curl nodejs npm netcat-openbsd bash
+RUN apk add --no-cache tini curl nodejs npm netcat-openbsd bash yq
 
 # Copy base configuration
-COPY docker-container/mediamtx.yml /mediamtx.base.yml
+COPY docker-container/mediamtx.yml /mediamtx.yml
 
 # Copy package files and install dependencies
 COPY docker-container/package*.json /app/


### PR DESCRIPTION
## Overview
This PR updates the local media-infra implementation to follow the upstream approach from [dfpc-coe/media-infra](https://github.com/dfpc-coe/media-infra), ensuring compatibility and consistency.

## Key Changes

### 🔄 **Configuration Management**
- **Before**: YAML file-based configuration with direct file writes
- **After**: MediaMTX REST API for dynamic path management (`/v3/config/paths/`)

### 🏗️ **Architecture Updates**
- Switch from `sourceOnDemand` to FFmpeg `runOnInit` commands for proxy streams
- Replace lazy cleanup with immediate API-based CRUD operations
- Update type definitions to match upstream (`RemotePath` → `CloudTAKRemotePath`)

### 🔧 **Technical Improvements**
- Add missing `yq` dependency for YAML processing
- Fix Docker configuration path mapping (`/mediamtx.yml` vs `/mediamtx.base.yml`)
- Update API endpoint to `/api/video/auth` (TAK-NZ specific)
- Simplify cron schedule from `0,10,20,30,40,50` to `*/10`

### 🐛 **Bug Fixes**
- Resolve MediaMTX API connection issues
- Fix container startup timing problems
- Ensure proper configuration loading

## Testing
- ✅ Container starts successfully
- ✅ MediaMTX API responds on port 9997
- ✅ Path synchronization works correctly
- ✅ No more "fetch failed" errors

## Breaking Changes
None - maintains backward compatibility with existing deployments.

## Files Modified
- `docker-container/persist.ts` - Complete rewrite to match upstream API approach
- `docker-container/start` - Simplified to match upstream pattern
- `docker-container/mediamtx.yml` - Minor configuration adjustments
- `docker/media-infra/Dockerfile` - Added `yq` dependency, fixed config path
